### PR TITLE
Add no italics alternate

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
         "label": "Night Owl",
         "uiTheme": "vs-dark",
         "path": "./themes/Night Owl-color-theme.json"
+      },
+      {
+        "label": "Night Owl No Italics",
+        "uiTheme": "vs-dark",
+        "path": "./themes/Night Owl-color-theme-noitalics.json"
       }
     ]
   }

--- a/themes/Night Owl-color-theme-noitalics.json
+++ b/themes/Night Owl-color-theme-noitalics.json
@@ -1,0 +1,1518 @@
+{
+    "name": "Night Owl",
+    "type": "dark",
+    "colors": {
+        "contrastActiveBorder": "#122d42",
+        "contrastBorder": "#122d42",
+        "focusBorder": "#122d42",
+        "foreground": "#d6deeb",
+        "widget.shadow": "#011627",
+        "selection.background": "#5f7e97",
+        "errorForeground": "#EF5350",
+        "button.background": "#7e57c2cc",
+        "button.foreground": "#ffffffcc",
+        "button.hoverBackground": "#7e57c2",
+        "dropdown.background": "#011627",
+        "dropdown.border": "#5f7e97",
+        "dropdown.foreground": "#ffffffcc",
+        "input.background": "#0b253a",
+        "input.border": "#5f7e97",
+        "input.foreground": "#ffffffcc",
+        "input.placeholderForeground": "#ffffffcc",
+        "inputOption.activeBorder": "#ffffffcc",
+        "punctuation.definition.generic.begin.html": "#ef5350f2",
+        "inputValidation.errorBackground": "#ef5350f2",
+        "inputValidation.errorBorder": "#EF5350",
+        "inputValidation.infoBackground": "#64b5f6f2",
+        "inputValidation.infoBorder": "#64B5F6",
+        "inputValidation.warningBackground": "#ffca28f2",
+        "inputValidation.warningBorder": "#FFCA28",
+        "scrollbar.shadow": "#010b14",
+        "scrollbarSlider.activeBackground": "#084d8180",
+        "scrollbarSlider.background": "#084d8180",
+        "scrollbarSlider.hoverBackground": "#084d8180",
+        "badge.background": "#5f7e97",
+        "badge.foreground": "#ffffff",
+        "progress.background": "#7e57c2",
+        "list.activeSelectionBackground": "#5f7e97",
+        "list.activeSelectionForeground": "#ffffff",
+        "list.dropBackground": "#011627",
+        "list.focusBackground": "#5f7e97",
+        "list.focusForeground": "#ffffff",
+        "list.highlightForeground": "#ffffff",
+        "list.hoverBackground": "#011627",
+        "list.hoverForeground": "#ffffff",
+        "list.inactiveSelectionBackground": "#0e293f",
+        "list.inactiveSelectionForeground": "#d2dee7",
+        "activityBar.background": "#011627",
+        "activityBar.dropBackground": "#5f7e97",
+        "activityBar.foreground": "#5f7e97",
+        "activityBar.border": "#011627",
+        "activityBarBadge.background": "#5f7e97",
+        "activityBarBadge.foreground": "#ffffff",
+        "sideBar.background": "#011627",
+        "sideBar.foreground": "#5f7e97",
+        "sideBar.border": "#011627",
+        "sideBarTitle.foreground": "#5f7e97",
+        "sideBarSectionHeader.background": "#011627",
+        "sideBarSectionHeader.foreground": "#5f7e97",
+        "editorGroup.background": "#32374C",
+        "editorGroup.border": "#011627",
+        "editorGroup.dropBackground": "#7e57c273",
+        "editorGroupHeader.noTabsBackground": "#32374C",
+        "editorGroupHeader.tabsBackground": "#011627",
+        "editorGroupHeader.tabsBorder": "#262A39",
+        "tab.activeBackground": "#0b2942",
+        "tab.activeForeground": "#d2dee7",
+        "tab.border": "#272B3B",
+        "tab.activeBorder": "#262A39",
+        "tab.unfocusedActiveBorder": "#262A39",
+        "tab.inactiveBackground": "#010e1a",
+        "tab.inactiveForeground": "#5f7e97",
+        "tab.unfocusedActiveForeground": "#5f7e97",
+        "tab.unfocusedInactiveForeground": "#5f7e97",
+        "editor.background": "#011627",
+        "editor.foreground": "#d6deeb",
+        "editorLineNumber.foreground": "#224058",
+        "editorCursor.foreground": "#7e57c2",
+        "editor.selectionBackground": "#1d3b53",
+        "editor.selectionHighlightBackground": "#011627",
+        "editor.inactiveSelectionBackground": "#7e57c25a",
+        "editor.wordHighlightBackground": "#32374D",
+        "editor.wordHighlightStrongBackground": "#2E3250",
+        "editor.findMatchBackground": "#5f7e97",
+        "editor.findMatchHighlightBackground": "#2E3248",
+        "editor.findRangeHighlightBackground": null,
+        "editor.hoverHighlightBackground": "#7e57c25a",
+        "editor.lineHighlightBackground": "#0003",
+        "editor.lineHighlightBorder": null,
+        "editorLink.activeForeground": null,
+        "editor.rangeHighlightBackground": "#7e57c25a",
+        "editorWhitespace.foreground": null,
+        "editorIndentGuide.background": "#011627",
+        "editorRuler.foreground": null,
+        "editorCodeLens.foreground": "#FFCA28",
+        "editorBracketMatch.background": "#5f7e97",
+        "editorBracketMatch.border": null,
+        "editorOverviewRuler.currentContentForeground": "#7e57c2",
+        "editorOverviewRuler.incomingContentForeground": "#7e57c2",
+        "editorOverviewRuler.commonContentForeground": "#7e57c2",
+        "editorError.foreground": "#EF5350",
+        "editorError.border": null,
+        "editorWarning.foreground": "#FFCA28",
+        "editorWarning.border": null,
+        "editorGutter.background": "#011627",
+        "editorGutter.modifiedBackground": "#e2b93d",
+        "editorGutter.addedBackground": "#9CCC65",
+        "editorGutter.deletedBackground": "#EF5350",
+        "diffEditor.insertedTextBackground": "#99b76d23",
+        "diffEditor.insertedTextBorder": "#addb6733",
+        "diffEditor.removedTextBackground": "#ef535033",
+        "diffEditor.removedTextBorder": "#ef53504d",
+        "editorWidget.background": "#31364a",
+        "editorWidget.border": "#262A39",
+        "editorSuggestWidget.background": "#2C3043",
+        "editorSuggestWidget.border": "#2B2F40",
+        "editorSuggestWidget.foreground": "#d6deeb",
+        "editorSuggestWidget.highlightForeground": "#ffffff",
+        "editorSuggestWidget.selectedBackground": "#5f7e97",
+        "editorHoverWidget.background": "#011627",
+        "editorHoverWidget.border": "#5f7e97",
+        "debugExceptionWidget.background": "#011627",
+        "debugExceptionWidget.border": "#5f7e97",
+        "editorMarkerNavigation.background": "#31364a",
+        "editorMarkerNavigationError.background": "#EF5350",
+        "editorMarkerNavigationWarning.background": "#FFCA28",
+        "peekView.border": "#5f7e97",
+        "peekViewEditor.background": "#011627",
+        "peekViewEditor.matchHighlightBackground": "#7e57c25a",
+        "peekViewResult.background": "#011627",
+        "peekViewResult.fileForeground": "#5f7e97",
+        "peekViewResult.lineForeground": "#5f7e97",
+        "peekViewResult.matchHighlightBackground": "#5f7e97",
+        "peekViewResult.selectionBackground": "#2E3250",
+        "peekViewResult.selectionForeground": "#5f7e97",
+        "peekViewTitle.background": "#011627",
+        "peekViewTitleDescription.foreground": "#697098",
+        "peekViewTitleLabel.foreground": "#5f7e97",
+        "merge.currentHeaderBackground": "#5f7e97",
+        "merge.currentContentBackground": null,
+        "merge.incomingHeaderBackground": "#7e57c25a",
+        "merge.incomingContentBackground": null,
+        "merge.border": null,
+        "panel.background": "#011627",
+        "panel.border": "#5f7e97",
+        "panelTitle.activeBorder": "#5f7e97",
+        "panelTitle.activeForeground": "#5f7e97",
+        "panelTitle.inactiveForeground": "#d6deeb80",
+        "statusBar.background": "#011627",
+        "statusBar.foreground": "#676E95",
+        "statusBar.border": "#262A39",
+        "statusBar.debuggingBackground": "#202431",
+        "statusBar.debuggingForeground": null,
+        "statusBar.debuggingBorder": "#1F2330",
+        "statusBar.noFolderForeground": null,
+        "statusBar.noFolderBackground": "#011627",
+        "statusBar.noFolderBorder": "#25293A",
+        "statusBarItem.activeBackground": "#202431",
+        "statusBarItem.hoverBackground": "#202431",
+        "statusBarItem.prominentBackground": "#202431",
+        "statusBarItem.prominentHoverBackground": "#202431",
+        "titleBar.activeBackground": "#30364c",
+        "titleBar.activeForeground": "#eeefff",
+        "titleBar.inactiveBackground": "#011627",
+        "titleBar.inactiveForeground": null,
+        "notifications.background": "#011627",
+        "notifications.foreground": "#ffffffcc",
+        "notificationLink.foreground": "#80CBC4",
+        "extensionButton.prominentForeground": "#ffffffcc",
+        "extensionButton.prominentBackground": "#7e57c2cc",
+        "extensionButton.prominentHoverBackground": "#7e57c2",
+        "pickerGroup.foreground": "#d1aaff",
+        "pickerGroup.border": "#011627",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiBlack": "#011627",
+        "terminal.ansiBlue": "#82AAFF",
+        "terminal.ansiCyan": "#7fdbca",
+        "terminal.ansiGreen": "#ba67db",
+        "terminal.ansiMagenta": "#C792EA",
+        "terminal.ansi#5f7e97": "#7fdbca",
+        "terminal.ansiYellow": "#addb67",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightBlack": "#575656",
+        "terminal.ansiBrightBlue": "#82AAFF",
+        "terminal.ansiBrightCyan": "#7fdbca",
+        "terminal.ansiBrightGreen": "#addb67",
+        "terminal.ansiBrightMagenta": "#C792EA",
+        "terminal.ansiBright#5f7e97": "#7fdbca",
+        "terminal.ansiBrightYellow": "#addb67",
+        "debugToolBar.background": "#011627",
+        "welcomePage.buttonBackground": "#011627",
+        "welcomePage.buttonHoverBackground": "#011627",
+        "walkThrough.embeddedEditorBackground": "#011627",
+        "gitDecoration.modifiedResourceForeground": "#e2c08de6",
+        "gitDecoration.deletedResourceForeground": "#EF535090",
+        "gitDecoration.untrackedResourceForeground": "#addb67ff",
+        "gitDecoration.igno#5f7e97ResourceForeground": "#011627",
+        "gitDecoration.conflictingResourceForeground": "#ffeb95cc",
+        "editorActiveLineNumber.foreground": "#5f7e97",
+        "string.quoted.single.js": "#ffffff",
+        "meta.objectliteral.js": "#82AAFF"
+    },
+    "tokenColors": [
+        {
+            "name": "Global settings",
+            "settings": {
+                "background": "#011627",
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Comment",
+            "scope": "comment",
+            "settings": {
+                "foreground": "#637777"
+            }
+        },
+        {
+            "name": "String",
+            "scope": "string",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "String Quoted",
+            "scope": [
+                "string.quoted",
+                "variable.other.readwrite.js"
+            ],
+            "settings": {
+                "foreground": "#ecc48d"
+            }
+        },
+        {
+            "name": "Support Constant Math",
+            "scope": "support.constant.math",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Number",
+            "scope": [
+                "constant.numeric",
+                "constant.character.numeric"
+            ],
+            "settings": {
+                "foreground": "#F78C6C"
+            }
+        },
+        {
+            "name": "Built-in constant",
+            "scope": [
+                "constant.language",
+                "punctuation.definition.constant",
+                "variable.other.constant"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "User-defined constant",
+            "scope": [
+                "constant.character",
+                "constant.other"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Constant Character Escape",
+            "scope": "constant.character.escape",
+            "settings": {
+                "foreground": "#F78C6C"
+            }
+        },
+        {
+            "name": "RegExp String",
+            "scope": [
+                "string.regexp",
+                "string.regexp keyword.other"
+            ],
+            "settings": {
+                "foreground": "#5ca7e4"
+            }
+        },
+        {
+            "name": "Comma in functions",
+            "scope": "meta.function punctuation.separator.comma",
+            "settings": {
+                "foreground": "#5f7e97"
+            }
+        },
+        {
+            "name": "Variable",
+            "scope": "variable",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Keyword",
+            "scope": [
+                "punctuation.accessor",
+                "keyword"
+            ],
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Storage",
+            "scope": "storage",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Storage type",
+            "scope": [
+                "storage.type",
+                "meta.var.expr storage.type",
+                "meta.class meta.method.declaration meta.var.expr storage.type.js"
+            ],
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Class name",
+            "scope": [
+                "entity.name.class",
+                "meta.class entity.name.type.class"
+            ],
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Inherited class",
+            "scope": "entity.other.inherited-class",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Function name",
+            "scope": "entity.name.function",
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Meta Tag",
+            "scope": [
+                "punctuation.definition.tag",
+                "meta.tag"
+            ],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "HTML Tag names",
+            "scope": [
+                "entity.name.tag support.class.component",
+                "meta.tag.other.html",
+                "meta.tag.other.js",
+                "meta.tag.other.tsx",
+                "entity.name.tag.tsx",
+                "entity.name.tag.js",
+                "entity.name.tag",
+                "meta.tag.js",
+                "meta.tag.tsx",
+                "meta.tag.html"
+            ],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Tag attribute",
+            "scope": "entity.other.attribute-name",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Entity Name Tag Custom",
+            "scope": "entity.name.tag.custom",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Library (function & constant)",
+            "scope": [
+                "support.function",
+                "support.constant"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Support Constant Property Value meta",
+            "scope": "support.constant.meta.property-value",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Library class/type",
+            "scope": [
+                "support.type",
+                "support.class"
+            ],
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Support Variable DOM",
+            "scope": "support.variable.dom",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Invalid",
+            "scope": "invalid",
+            "settings": {
+                "background": "#ff2c83",
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Invalid deprecated",
+            "scope": "invalid.deprecated",
+            "settings": {
+                "foreground": "#ffffff",
+                "background": "#d3423e"
+            }
+        },
+        {
+            "name": "Keyword Operator",
+            "scope": "keyword.operator",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Keyword Operator Relational",
+            "scope": "keyword.operator.relational",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Keyword Operator Assignment",
+            "scope": "keyword.operator.assignment",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Double-Slashed Comment",
+            "scope": "comment.line.double-slash",
+            "settings": {
+                "foreground": "#637777"
+            }
+        },
+        {
+            "name": "Object",
+            "scope": "object",
+            "settings": {
+                "foreground": "#cdebf7"
+            }
+        },
+        {
+            "name": "Null",
+            "scope": "constant.language.null",
+            "settings": {
+                "foreground": "#ff5874"
+            }
+        },
+        {
+            "name": "Meta Brace",
+            "scope": "meta.brace",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Meta Delimiter Period",
+            "scope": "meta.delimiter.period",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Punctuation Definition String",
+            "scope": "punctuation.definition.string",
+            "settings": {
+                "foreground": "#d9f5dd"
+            }
+        },
+        {
+            "name": "Boolean",
+            "scope": "constant.language.boolean",
+            "settings": {
+                "foreground": "#ff5874"
+            }
+        },
+        {
+            "name": "Object Comma",
+            "scope": "object.comma",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Variable Parameter Function",
+            "scope": "variable.parameter.function",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Support Type Property Name & entity name tags",
+            "scope": [
+                "support.type.vendo#5f7e97.property-name",
+                "support.constant.vendo#5f7e97.property-value",
+                "support.type.property-name",
+                "meta.property-list entity.name.tag"
+            ],
+            "settings": {
+                "foreground": "#80CBC4"
+            }
+        },
+        {
+            "name": "Entity Name tag reference in stylesheets",
+            "scope": "meta.property-list entity.name.tag.reference",
+            "settings": {
+                "foreground": "#57eaf1"
+            }
+        },
+        {
+            "name": "Constant Other Color RGB Value Punctuation Definition Constant",
+            "scope": "constant.other.color.rgb-value punctuation.definition.constant",
+            "settings": {
+                "foreground": "#F78C6C"
+            }
+        },
+        {
+            "name": "Constant Other Color",
+            "scope": "constant.other.color",
+            "settings": {
+                "foreground": "#FFEB95"
+            }
+        },
+        {
+            "name": "Keyword Other Unit",
+            "scope": "keyword.other.unit",
+            "settings": {
+                "foreground": "#FFEB95"
+            }
+        },
+        {
+            "name": "Meta Selector",
+            "scope": "meta.selector",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Entity Other Attribute Name Id",
+            "scope": "entity.other.attribute-name.id",
+            "settings": {
+                "foreground": "#FAD430"
+            }
+        },
+        {
+            "name": "Meta Property Name",
+            "scope": "meta.property-name",
+            "settings": {
+                "foreground": "#80CBC4"
+            }
+        },
+        {
+            "name": "Doctypes",
+            "scope": [
+                "entity.name.tag.doctype",
+                "meta.tag.sgml.doctype"
+            ],
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Punctuation Definition Parameters",
+            "scope": "punctuation.definition.parameters",
+            "settings": {
+                "foreground": "#d9f5dd"
+            }
+        },
+        {
+            "name": "Keyword Control Operator",
+            "scope": "keyword.control.operator",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Keyword Operator Logical",
+            "scope": "keyword.operator.logical",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Variable Instances",
+            "scope": [
+                "variable.instance",
+                "variable.other.instance",
+                "variable.readwrite.instance",
+                "variable.other.readwrite.instance",
+                "variable.other.property"
+            ],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Variable Property Other object",
+            "scope": [
+                "variable.other.object.property"
+            ],
+            "settings": {
+                "foreground": "#d7dbe0"
+            }
+        },
+        {
+            "name": "Entity Name Function",
+            "scope": "entity.name.function",
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Keyword Operator Comparison",
+            "scope": "keyword.operator.comparison",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Support Constant, `new` keyword, Special Method Keyword",
+            "scope": [
+                "support.constant",
+                "keyword.other.special-method",
+                "keyword.other.new"
+            ],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Support Function",
+            "scope": "support.function",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Invalid Broken",
+            "scope": "invalid.broken",
+            "settings": {
+                "foreground": "#020e14",
+                "background": "#F78C6C"
+            }
+        },
+        {
+            "name": "Invalid Unimplemented",
+            "scope": "invalid.unimplemented",
+            "settings": {
+                "background": "#8BD649",
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Invalid Illegal",
+            "scope": "invalid.illegal",
+            "settings": {
+                "foreground": "#ffffff",
+                "background": "#ec5f67"
+            }
+        },
+        {
+            "name": "Language Variable",
+            "scope": "variable.language",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Support Variable Property",
+            "scope": "support.variable.property",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Variable Function",
+            "scope": "variable.function",
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Variable Interpolation",
+            "scope": "variable.interpolation",
+            "settings": {
+                "foreground": "#ec5f67"
+            }
+        },
+        {
+            "name": "Meta Function Call",
+            "scope": "meta.function-call",
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Punctuation Section Embedded",
+            "scope": "punctuation.section.embedded",
+            "settings": {
+                "foreground": "#d3423e"
+            }
+        },
+        {
+            "name": "Punctuation Tweaks",
+            "scope": [
+                "punctuation.terminator.expression",
+                "punctuation.definition.arguments",
+                "punctuation.definition.array",
+                "punctuation.section.array",
+                "meta.array"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "More Punctuation Tweaks",
+            "scope": [
+                "punctuation.definition.list.begin",
+                "punctuation.definition.list.end",
+                "punctuation.separator.arguments",
+                "punctuation.definition.list"
+            ],
+            "settings": {
+                "foreground": "#d9f5dd"
+            }
+        },
+        {
+            "name": "Template Strings",
+            "scope": "string.template meta.template.expression",
+            "settings": {
+                "foreground": "#d3423e"
+            }
+        },
+        {
+            "name": "Backtics(``) in Template Strings",
+            "scope": "string.template punctuation.definition.string",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Italics",
+            "scope": "italic",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Bold",
+            "scope": "bold",
+            "settings": {
+                "foreground": "#addb67",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Quote",
+            "scope": "quote",
+            "settings": {
+                "foreground": "#697098"
+            }
+        },
+        {
+            "name": "Raw Code",
+            "scope": "raw",
+            "settings": {
+                "foreground": "#80CBC4"
+            }
+        },
+        {
+            "name": "CoffeScript Variable Assignment",
+            "scope": "variable.assignment.coffee",
+            "settings": {
+                "foreground": "#31e1eb"
+            }
+        },
+        {
+            "name": "CoffeScript Parameter Function",
+            "scope": "variable.parameter.function.coffee",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "CoffeeScript Assignments",
+            "scope": "variable.assignment.coffee",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "C# Readwrite Variables",
+            "scope": "variable.other.readwrite.cs",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "C# Classes & Storage types",
+            "scope": [
+                "entity.name.type.class.cs",
+                "storage.type.cs"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "C# Namespaces",
+            "scope": "entity.name.type.namespace.cs",
+            "settings": {
+                "foreground": "#B2CCD6"
+            }
+        },
+        {
+            "name": "Tag names in Stylesheets",
+            "scope": [
+                "entity.name.tag.css",
+                "entity.name.tag.less",
+                "entity.name.tag.custom.css",
+                "support.constant.property-value.css"
+            ],
+            "settings": {
+                "foreground": "#ff6363",
+                "fontStyle": "None"
+            }
+        },
+        {
+            "name": "Wildcard(*) selector in Stylesheets",
+            "scope": [
+                "entity.name.tag.wildcard.css",
+                "entity.name.tag.wildcard.less",
+                "entity.name.tag.wildcard.scss",
+                "entity.name.tag.wildcard.sass"
+            ],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "CSS Keyword Other Unit",
+            "scope": "keyword.other.unit.css",
+            "settings": {
+                "foreground": "#FFEB95"
+            }
+        },
+        {
+            "name": "Attribute Name for CSS",
+            "scope": [
+                "meta.attribute-selector.css entity.other.attribute-name.attribute",
+                "variable.other.readwrite.js"
+            ],
+            "settings": {
+                "foreground": "#F78C6C"
+            }
+        },
+        {
+            "name": "Elixir Classes",
+            "scope": [
+                "source.elixir support.type.elixir",
+                "source.elixir meta.module.elixir entity.name.class.elixir"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Elixir Functions",
+            "scope": "source.elixir entity.name.function",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Elixir Constants",
+            "scope": [
+                "source.elixir constant.other.symbol.elixir",
+                "source.elixir constant.other.keywords.elixir"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Elixir String Punctuations",
+            "scope": "source.elixir punctuation.definition.string",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Elixir",
+            "scope": [
+                "source.elixir variable.other.readwrite.module.elixir",
+                "source.elixir variable.other.readwrite.module.elixir punctuation.definition.variable.elixir"
+            ],
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Elixir Binary Punctuations",
+            "scope": "source.elixir .punctuation.binary.elixir",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Go Function Calls",
+            "scope": "source.go meta.function-call.go",
+            "settings": {
+                "foreground": "#DDDDDD"
+            }
+        },
+        {
+            "name": "ID Attribute Name in HTML",
+            "scope": "entity.other.attribute-name.id.html",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "HTML Punctuation Definition Tag",
+            "scope": "punctuation.definition.tag.html",
+            "settings": {
+                "foreground": "#6ae9f0"
+            }
+        },
+        {
+            "name": "HTML Doctype",
+            "scope": "meta.tag.sgml.doctype.html",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "JavaScript Classes",
+            "scope": "meta.class entity.name.type.class.js",
+            "settings": {
+                "foreground": "#ffcb8b"
+            }
+        },
+        {
+            "name": "JavaScript Method Declaration e.g. `constructor`",
+            "scope": "meta.method.declaration storage.type.js",
+            "settings": {
+                "foreground": "#82AAFF",
+                "fontStyle": "normal"
+            }
+        },
+        {
+            "name": "JavaScript Terminator",
+            "scope": "terminator.js",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "JavaScript Meta Punctuation Definition",
+            "scope": "meta.js punctuation.definition.js",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Entity Names in Code Documentations",
+            "scope": [
+                "entity.name.type.instance.jsdoc",
+                "entity.name.type.instance.phpdoc"
+            ],
+            "settings": {
+                "foreground": "#5f7e97"
+            }
+        },
+        {
+            "name": "Other Variables in Code Documentations",
+            "scope": [
+                "variable.other.jsdoc",
+                "variable.other.phpdoc"
+            ],
+            "settings": {
+                "foreground": "#78ccf0"
+            }
+        },
+        {
+            "name": "JavaScript module imports and exports",
+            "scope": [
+                "variable.other.meta.import.js",
+                "meta.import.js variable.other",
+                "variable.other.meta.export.js",
+                "meta.export.js variable.other"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "JavaScript Variable Parameter Function",
+            "scope": "variable.parameter.function.js",
+            "settings": {
+                "foreground": "#7986E7"
+            }
+        },
+        {
+            "name": "Text nested in React tags",
+            "scope": [
+                "meta.jsx.children",
+                "meta.jsx.children.js",
+                "meta.jsx.children.tsx"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "JavaScript[React] Variable Other Object",
+            "scope": [
+                "variable.other.object.js",
+                "variable.other.object.jsx",
+                "variable.object.property.js",
+                "variable.object.property.jsx"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "JavaScript Variables",
+            "scope": [
+                "variable.js",
+                "variable.other.js"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "JavaScript Entity Name Type",
+            "scope": [
+                "entity.name.type.js",
+                "entity.name.type.module.js"
+            ],
+            "settings": {
+                "foreground": "#ffcb8b"
+            }
+        },
+        {
+            "name": "JavaScript Support Classes",
+            "scope": "support.class.js",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "JSON Property Names",
+            "scope": "support.type.property-name.json",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "JSON Support Constants",
+            "scope": "support.constant.json",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "JSON Property values (string)",
+            "scope": "meta.structure.dictionary.value.json string.quoted.double",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Strings in JSON values",
+            "scope": "string.quoted.double.json punctuation.definition.string.json",
+            "settings": {
+                "foreground": "#80CBC4"
+            }
+        },
+        {
+            "name": "Specific JSON Property values like null",
+            "scope": "meta.structure.dictionary.json meta.structure.dictionary.value constant.language",
+            "settings": {
+                "foreground": "#ff5874"
+            }
+        },
+        {
+            "name": "Ruby Variables",
+            "scope": "variable.other.ruby",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Ruby Hashkeys",
+            "scope": "constant.language.symbol.hashkey.ruby",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "LESS Tag names",
+            "scope": "entity.name.tag.less",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "LESS Keyword Other Unit",
+            "scope": "keyword.other.unit.css",
+            "settings": {
+                "foreground": "#FFEB95"
+            }
+        },
+        {
+            "name": "Attribute Name for LESS",
+            "scope": "meta.attribute-selector.less entity.other.attribute-name.attribute",
+            "settings": {
+                "foreground": "#F78C6C"
+            }
+        },
+        {
+            "name": "Markdown Headings",
+            "scope": "markup.heading.markdown",
+            "settings": {
+                "foreground": "#82b1ff"
+            }
+        },
+        {
+            "name": "Markdown Italics",
+            "scope": "markup.italic.markdown",
+            "settings": {
+                "foreground": "#c792ea"
+            }
+        },
+        {
+            "name": "Markdown Bold",
+            "scope": "markup.bold.markdown",
+            "settings": {
+                "foreground": "#addb67",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Markdown Quote + others",
+            "scope": "markup.quote.markdown",
+            "settings": {
+                "foreground": "#697098"
+            }
+        },
+        {
+            "name": "Markdown Raw Code + others",
+            "scope": "markup.inline.raw.markdown",
+            "settings": {
+                "foreground": "#80CBC4"
+            }
+        },
+        {
+            "name": "Markdown Links",
+            "scope": [
+                "markup.underline.link.markdown",
+                "markup.underline.link.image.markdown"
+            ],
+            "settings": {
+                "foreground": "#ff869a"
+            }
+        },
+        {
+            "name": "Markdown Link Title and Description",
+            "scope": [
+                "string.other.link.title.markdown",
+                "string.other.link.description.markdown"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Markdown Punctuation",
+            "scope": [
+                "punctuation.definition.string.markdown",
+                "punctuation.definition.string.begin.markdown",
+                "punctuation.definition.string.end.markdown",
+                "meta.link.inline.markdown punctuation.definition.string"
+            ],
+            "settings": {
+                "foreground": "#82b1ff"
+            }
+        },
+        {
+            "name": "Markdown MetaData Punctuation",
+            "scope": [
+                "punctuation.definition.metadata.markdown"
+            ],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "Markdown List Punctuation",
+            "scope": [
+                "beginning.punctuation.definition.list.markdown"
+            ],
+            "settings": {
+                "foreground": "#82b1ff"
+            }
+        },
+        {
+            "name": "PHP Variables",
+            "scope": "variable.other.php",
+            "settings": {
+                "foreground": "#bec5d4"
+            }
+        },
+        {
+            "name": "Support Classes in PHP",
+            "scope": "support.class.php",
+            "settings": {
+                "foreground": "#ffcb8b"
+            }
+        },
+        {
+            "name": "Punctuations in PHP function calls",
+            "scope": "meta.function-call.php punctuation",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "PHP Global Variables",
+            "scope": "variable.other.global.php",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Declaration Punctuation in PHP Global Variables",
+            "scope": "variable.other.global.php punctuation.definition.variable",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Language Constants in Python",
+            "scope": "constant.language.python",
+            "settings": {
+                "foreground": "#ff5874"
+            }
+        },
+        {
+            "name": "Python Function Parameter and Arguments",
+            "scope": [
+                "variable.parameter.function.python",
+                "meta.function-call.arguments.python"
+            ],
+            "settings": {
+                "foreground": "#7986E7"
+            }
+        },
+        {
+            "name": "Python Function Call",
+            "scope": [
+                "meta.function-call.python",
+                "meta.function-call.generic.python"
+            ],
+            "settings": {
+                "foreground": "#B2CCD6"
+            }
+        },
+        {
+            "name": "Punctuations in Python",
+            "scope": "punctuation.python",
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "Decorator Functions in Python",
+            "scope": "entity.name.function.decorator.python",
+            "settings": {
+                "foreground": "#addb67"
+            }
+        },
+        {
+            "name": "Python Language Variable",
+            "scope": "source.python variable.language.special",
+            "settings": {
+                "foreground": "#8EACE3"
+            }
+        },
+        {
+            "name": "SCSS Variable",
+            "scope": [
+                "variable.scss",
+                "variable.sass",
+                "variable.parameter.url.scss",
+                "variable.parameter.url.sass"
+            ],
+            "settings": {
+                "foreground": "#DDDDDD"
+            }
+        },
+        {
+            "name": "Variables in SASS At-Rules",
+            "scope": [
+                "source.css.scss meta.at-rule variable",
+                "source.css.sass meta.at-rule variable"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "Variables in SASS At-Rules",
+            "scope": [
+                "source.css.scss meta.at-rule variable",
+                "source.css.sass meta.at-rule variable"
+            ],
+            "settings": {
+                "foreground": "#bec5d4"
+            }
+        },
+        {
+            "name": "Attribute Name for SASS",
+            "scope": [
+                "meta.attribute-selector.scss entity.other.attribute-name.attribute",
+                "meta.attribute-selector.sass entity.other.attribute-name.attribute"
+            ],
+            "settings": {
+                "foreground": "#F78C6C"
+            }
+        },
+        {
+            "name": "Tag names in SASS",
+            "scope": [
+                "entity.name.tag.scss",
+                "entity.name.tag.sass"
+            ],
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "SASS Keyword Other Unit",
+            "scope": [
+                "keyword.other.unit.scss",
+                "keyword.other.unit.sass"
+            ],
+            "settings": {
+                "foreground": "#FFEB95"
+            }
+        },
+        {
+            "name": "TypeScript[React] Variables and Object Properties",
+            "scope": [
+                "variable.other.readwrite.alias.ts",
+                "variable.other.readwrite.alias.tsx",
+                "variable.other.readwrite.ts",
+                "variable.other.readwrite.tsx",
+                "variable.other.object.ts",
+                "variable.other.object.tsx",
+                "variable.object.property.ts",
+                "variable.object.property.tsx",
+                "variable.other.ts",
+                "variable.other.tsx",
+                "variable.tsx",
+                "variable.ts"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "TypeScript[React] Entity Name Types",
+            "scope": [
+                "entity.name.type.ts",
+                "entity.name.type.tsx"
+            ],
+            "settings": {
+                "foreground": "#78ccf0"
+            }
+        },
+        {
+            "name": "TypeScript[React] Node Classes",
+            "scope": [
+                "support.class.node.ts",
+                "support.class.node.tsx"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "TypeScript[React] Entity Name Types as Parameters",
+            "scope": [
+                "meta.type.parameters.ts entity.name.type",
+                "meta.type.parameters.tsx entity.name.type"
+            ],
+            "settings": {
+                "foreground": "#5f7e97"
+            }
+        },
+        {
+            "name": "TypeScript[React] Import/Export Punctuations",
+            "scope": [
+                "meta.import.ts punctuation.definition.block",
+                "meta.import.tsx punctuation.definition.block",
+                "meta.export.ts punctuation.definition.block",
+                "meta.export.tsx punctuation.definition.block"
+            ],
+            "settings": {
+                "foreground": "#d6deeb"
+            }
+        },
+        {
+            "name": "TypeScript[React] Punctuation Decorators",
+            "scope": [
+                "meta.decorator punctuation.decorator.ts",
+                "meta.decorator punctuation.decorator.tsx"
+            ],
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "TypeScript[React] Punctuation Decorators",
+            "scope": "meta.tag.js meta.jsx.children.tsx",
+            "settings": {
+                "foreground": "#82AAFF"
+            }
+        },
+        {
+            "name": "YAML Entity Name Tags",
+            "scope": "entity.name.tag.yaml",
+            "settings": {
+                "foreground": "#7fdbca"
+            }
+        },
+        {
+            "name": "JavaScript Variable Other ReadWrite",
+            "scope": [
+                "variable.other.readwrite.js",
+                "variable.parameter"
+            ],
+            "settings": {
+                "foreground": "#d7dbe0"
+            }
+        },
+        {
+            "name": "normalize font style of certain components",
+            "scope": [
+                "meta.property-list.css meta.property-value.css variable.other.less",
+                "meta.property-list.scss variable.scss",
+                "meta.property-list.sass variable.sass",
+                "keyword.operator.logical",
+                "keyword.operator.arithmetic",
+                "keyword.operator.bitwise",
+                "keyword.operator.increment",
+                "keyword.operator.ternary",
+                "keyword.operator.comparison",
+                "keyword.operator.assignment",
+                "keyword.operator.operator",
+                "keyword.operator.or.regexp",
+                "keyword.operator.expression.in",
+                "keyword.operator.type",
+                "punctuation.definintion.string",
+                "punctuation",
+                "source.css"
+            ],
+            "settings": {
+                "fontStyle": "None"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Resolves #14 

I have never so much as considered writing a theme or extension for vscode so I have no idea if this is an appropriate solution. I added another theme in `themes/Night Owl-color-theme-noitalics.json`. 99% of the code is duplicated from `themes/Night Owl-color-theme.json` so maybe there's a better way to do this. This solution simply adds a new theme to vscode called `Night Owl No Italics`. I am completely open to suggestions on how to improve this.