### PR TITLE
Change foreground color for placeholders

### DIFF
--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -18,7 +18,7 @@
     "input.background": "#0b253a",
     "input.border": "#5f7e97",
     "input.foreground": "#ffffffcc",
-    "input.placeholderForeground": "#ffffffcc",
+    "input.placeholderForeground": "#5f7e97",
     "inputOption.activeBorder": "#ffffffcc",
     "punctuation.definition.generic.begin.html": "#ef5350f2",
     "inputValidation.errorBackground": "#ef5350f2",


### PR DESCRIPTION
Thank you for working on this theme!

I noticed that the placeholders' foreground colors are the same as that of normal text colors. This creates a slight confusion while searching.

Before:
<img width="384" alt="screen shot 2018-05-21 at 9 38 48 pm" src="https://user-images.githubusercontent.com/7725225/40317701-debc0dc6-5d3f-11e8-9013-283d53acfe2e.png">

After:
<img width="384" alt="screen shot 2018-05-21 at 9 39 03 pm" src="https://user-images.githubusercontent.com/7725225/40317705-e02548da-5d3f-11e8-8192-22ff93547f57.png">
