### PR TITLE
fix editor ruler color

### DIFF
--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -91,7 +91,7 @@
     "editor.rangeHighlightBackground": "#7e57c25a",
     "editorWhitespace.foreground": null,
     "editorIndentGuide.background": "#5e81ce52",
-    "editorRuler.foreground": null,
+    "editorRuler.foreground": "#5e81ce52",
     "editorCodeLens.foreground": "#5e82ceb4",
     "editorBracketMatch.background": "#5f7e974d",
     "editorBracketMatch.border": null,


### PR DESCRIPTION
Hello Sarah, great theme!

Just a tiny fix for those of us who use editor.rulers setting for keeping track of line lengths.

The ruler now uses the same blue as the indentation lines, instead of the standard grayish color.

Before:
![skarmavbild 2018-05-25 kl 22 09 54](https://user-images.githubusercontent.com/31779292/40565055-5af727f8-606b-11e8-91fe-bd6a91bd29f5.png)
After:
![skarmavbild 2018-05-25 kl 22 11 25](https://user-images.githubusercontent.com/31779292/40565062-5f5c7960-606b-11e8-94c8-c96fe1ab2cc3.png)

Thanks!