### PR TITLE
Increase contrast for line number foreground

### DIFF
--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -74,7 +74,8 @@
     "tab.unfocusedInactiveForeground": "#5f7e97",
     "editor.background": "#011627",
     "editor.foreground": "#d6deeb",
-    "editorLineNumber.foreground": "#224058",
+    "editorLineNumber.foreground": "#5f7e97",
+    "editorLineNumber.activeForeground": "#C5E4FD",
     "editorCursor.foreground": "#7e57c2",
     "editor.selectionBackground": "#1d3b53",
     "editor.selectionHighlightBackground": "#5f7e9779",
@@ -196,7 +197,6 @@
     "gitDecoration.untrackedResourceForeground": "#addb67ff",
     "gitDecoration.ignoredResourceForeground": "#395a75",
     "gitDecoration.conflictingResourceForeground": "#ffeb95cc",
-    "editorActiveLineNumber.foreground": "#5f7e97",
     "source.elm": "#5f7e97",
     "string.quoted.single.js": "#ffffff",
     "meta.objectliteral.js": "#82AAFF"

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -74,7 +74,8 @@
     "tab.unfocusedInactiveForeground": "#5f7e97",
     "editor.background": "#011627",
     "editor.foreground": "#d6deeb",
-    "editorLineNumber.foreground": "#224058",
+    "editorLineNumber.foreground": "#5f7e97",
+    "editorLineNumber.activeForeground": "#C5E4FD",
     "editorCursor.foreground": "#7e57c2",
     "editor.selectionBackground": "#1d3b53",
     "editor.selectionHighlightBackground": "#5f7e9779",
@@ -196,7 +197,6 @@
     "gitDecoration.untrackedResourceForeground": "#addb67ff",
     "gitDecoration.ignoredResourceForeground": "#395a75",
     "gitDecoration.conflictingResourceForeground": "#ffeb95cc",
-    "editorActiveLineNumber.foreground": "#5f7e97",
     "source.elm": "#5f7e97",
     "string.quoted.single.js": "#ffffff",
     "meta.objectliteral.js": "#82AAFF"


### PR DESCRIPTION
This fixes https://github.com/sdras/night-owl-vscode-theme/issues/60

Before:
![image](https://user-images.githubusercontent.com/4671080/40689604-df6c5c30-6370-11e8-8e7f-1e9f7e044119.png)

After:
![image](https://user-images.githubusercontent.com/4671080/40689607-e2a892b0-6370-11e8-9b4e-ce722dab5ba5.png)
