### PR TITLE
Fixing typescript 'import' and 'from' reserved words color

### DIFF
--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -688,7 +688,9 @@
         "keyword.control.ruby",
         "keyword.control.def.ruby",
         "keyword.control.import.js",
-        "keyword.control.from.js"
+        "keyword.control.import.ts",
+        "keyword.control.from.js",
+        "keyword.control.from.ts"
       ],
       "settings": {
         "foreground": "#c792ea",

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -688,7 +688,9 @@
         "keyword.control.def.ruby",
         "keyword.control.loop.js",
         "keyword.control.import.js",
-        "keyword.control.from.js"
+        "keyword.control.import.ts",
+        "keyword.control.from.js",
+        "keyword.control.from.ts"
       ],
       "settings": {
         "foreground": "#c792ea",


### PR DESCRIPTION
This fixes https://github.com/sdras/night-owl-vscode-theme/issues/58