### PR TITLE
Making the cursor more visible with a bright blue color

### DIFF
--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -76,7 +76,7 @@
     "editor.foreground": "#d6deeb",
     "editorLineNumber.foreground": "#4b6479",
     "editorLineNumber.activeForeground": "#C5E4FD",
-    "editorCursor.foreground": "#7e57c2",
+    "editorCursor.foreground": "#5f7e97",
     "editor.selectionBackground": "#1d3b53",
     "editor.selectionHighlightBackground": "#5f7e9779",
     "editor.inactiveSelectionBackground": "#7e57c25a",

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -76,7 +76,7 @@
     "editor.foreground": "#d6deeb",
     "editorLineNumber.foreground": "#4b6479",
     "editorLineNumber.activeForeground": "#C5E4FD",
-    "editorCursor.foreground": "#7e57c2",
+    "editorCursor.foreground": "#5f7e97",
     "editor.selectionBackground": "#1d3b53",
     "editor.selectionHighlightBackground": "#5f7e9779",
     "editor.inactiveSelectionBackground": "#7e57c25a",


### PR DESCRIPTION
This closes https://github.com/sdras/night-owl-vscode-theme/issues/79

This is how it looks now after the changes we talked about on https://github.com/sdras/night-owl-vscode-theme/pull/81:
![image](https://user-images.githubusercontent.com/4671080/41257261-343c8bbc-6d9a-11e8-8b21-79d17b36d682.png)
