### PR TITLE
Adding a lighter color for Active Indent Guide

### DIFF
--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -92,6 +92,7 @@
     "editor.rangeHighlightBackground": "#7e57c25a",
     "editorWhitespace.foreground": null,
     "editorIndentGuide.background": "#5e81ce52",
+    "editorIndentGuide.activeBackground": "#7E97AC",
     "editorRuler.foreground": "#5e82ceb4",
     "editorCodeLens.foreground": "#5e82ceb4",
     "editorBracketMatch.background": "#5f7e974d",

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -92,6 +92,7 @@
     "editor.rangeHighlightBackground": "#7e57c25a",
     "editorWhitespace.foreground": null,
     "editorIndentGuide.background": "#5e81ce52",
+    "editorIndentGuide.activeBackground": "#7E97AC",
     "editorRuler.foreground": "#5e81ce52",
     "editorCodeLens.foreground": "#5e82ceb4",
     "editorBracketMatch.background": "#5f7e974d",


### PR DESCRIPTION
This closes https://github.com/sdras/night-owl-vscode-theme/issues/88

This is how it looks now:
![image](https://user-images.githubusercontent.com/4671080/41441455-a3041854-7000-11e8-9023-027c81d71d13.png)
