### PR TITLE
Fixing tab bar color when showTabs is false

### DIFF
--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -60,7 +60,7 @@
     "editorGroup.background": "#32374C",
     "editorGroup.border": "#011627",
     "editorGroup.dropBackground": "#7e57c273",
-    "editorGroupHeader.noTabsBackground": "#32374C",
+    "editorGroupHeader.noTabsBackground": "#011627",
     "editorGroupHeader.tabsBackground": "#011627",
     "editorGroupHeader.tabsBorder": "#262A39",
     "tab.activeBackground": "#0b2942",

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -60,7 +60,7 @@
     "editorGroup.background": "#32374C",
     "editorGroup.border": "#011627",
     "editorGroup.dropBackground": "#7e57c273",
-    "editorGroupHeader.noTabsBackground": "#32374C",
+    "editorGroupHeader.noTabsBackground": "#011627",
     "editorGroupHeader.tabsBackground": "#011627",
     "editorGroupHeader.tabsBorder": "#262A39",
     "tab.activeBackground": "#0b2942",


### PR DESCRIPTION
This closes https://github.com/sdras/night-owl-vscode-theme/issues/99

Here how it looks:
![image](https://user-images.githubusercontent.com/4671080/41804674-a1ddfc88-7668-11e8-8e3f-26dd727665b0.png)
