### PR TITLE
Fix get/set, storage.type (was overridden)

### DIFF
--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -335,7 +335,10 @@
       "scope": [
         "storage",
         "meta.var.expr",
-        "meta.class meta.method.declaration meta.var.expr storage.type.js"
+        "meta.class meta.method.declaration meta.var.expr storage.type.js",
+        "storage.type.property.js",
+        "storage.type.property.ts",
+        "storage.type.property.tsx"
       ],
       "settings": {
         "foreground": "#c792ea",
@@ -346,7 +349,7 @@
       "name": "Storage type",
       "scope": "storage.type",
       "settings": {
-        "foreground": "#c792ea"
+        "foreground": "#82AAFF"
       }
     },
     {
@@ -1071,10 +1074,9 @@
     },
     {
       "name": "JavaScript Method Declaration e.g. `constructor`",
-      "scope": ["meta.method.declaration storage.type.js", "storage.type"],
+      "scope": "meta.method.declaration storage.type.js",
       "settings": {
-        "foreground": "#82AAFF",
-        "fontStyle": ""
+        "foreground": "#82AAFF"
       }
     },
     {
@@ -1585,7 +1587,10 @@
     },
     {
       "name": "TypeScript Method Declaration e.g. `constructor`",
-      "scope": "meta.method.declaration storage.type.tsx",
+      "scope": [
+        "meta.method.declaration storage.type.ts",
+        "meta.method.declaration storage.type.tsx"
+      ],
       "settings": {
         "foreground": "#82AAFF"
       }


### PR DESCRIPTION
- [x] `get`/`set` colored and italicized for JS/JSX/TS/TSX.
- [x] `storage.type` was overridden, so I removed it from the `JavaScript Method Declaration e.g. constructor` scope and changed color.
- [x] Added `.ts` to the method declaration scope.

How it looks now in JS/JSX/TS/TSX
![getset](https://user-images.githubusercontent.com/30043375/41989766-10a8a7b0-7a49-11e8-8816-80472b461e8f.png)
