### PR TITLE
🐛 FIX: Replace the buggy shields bagde

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Night Owl 🌌
 
 [![Version](https://vsmarketplacebadge.apphb.com/version/sdras.night-owl.svg)](https://aka.ms/nightowl)
-[![Downloads](https://img.shields.io/vscode-marketplace/d/sdras.night-owl.svg)](https://aka.ms/nightowl)
+[![Downloads](https://img.shields.io/vscode-marketplace/r/sdras.night-owl.svg)](https://aka.ms/nightowl)
 
 A VS Code theme for the night owls out there. Works well in the daytime, too, but this theme is fine-tuned for those of us who like to code late into the night. Color choices have taken into consideration what is accessible to people with colorblindness and in low-light circumstances. Decisions were also based on meaningful contrast for reading comprehension and for optimal razzle dazzle. ✨
 


### PR DESCRIPTION
Thanks for the awesome theme Sarah. I've also authored a [purple VSCode theme](https://marketplace.visualstudio.com/items?itemName=ahmadawais.shades-of-purple). The shields badge for downloads which was working alright is now buggy. It was reporting fewer downloads than actual so I removed it.

I first thought it was only for my theme but apparently, it's reporting 20k fewer downloads for Night Owl as well. So, I figured you'd want to remove it.

I replaced it with the reviews badge.