### PR TITLE
Added markdown coloring

### DIFF
--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -1357,6 +1357,13 @@
       }
     },
     {
+      "name": "Markdown Inline Raw String",
+      "scope": "markup.inline.raw.string.markdown",
+      "settings": {
+        "foreground": "#addb67"
+      }
+    },
+    {
       "name": "PHP Variables",
       "scope": "variable.other.php",
       "settings": {

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -1368,6 +1368,13 @@
       }
     },
     {
+      "name": "Markdown Inline Raw String",
+      "scope": "markup.inline.raw.string.markdown",
+      "settings": {
+        "foreground": "#addb67"
+      }
+    },
+    {
       "name": "PHP Variables",
       "scope": ["variable.other.php", "variable.other.property.php"],
       "settings": {


### PR DESCRIPTION
Added markdown coloring for an inline raw string inside backticks.

Closes #141

### Before
![](https://user-images.githubusercontent.com/10441177/45929771-f307b600-bf5e-11e8-8b99-89d0c36119c2.png)

### After

![](https://user-images.githubusercontent.com/14850464/45965329-ced2d480-c045-11e8-95bb-9c7b87d444a9.png)