### PR TITLE
Fix C/C++ syntax for readability

### DIFF
--- a/demo/c.c
+++ b/demo/c.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+ 
+#define thirtytwo 32
+#define D_CONST thirtytwo
+
+int pascals(int *x, int *y, int d)
+{
+	int i;
+	for (i = 1; i < d; i++)
+		printf("%d%c", y[i] = x[i - 1] + x[i],
+			i < d - 1 ? ' ' : '\n');
+ 
+	return D_CONST > d ? pascals(y, x, d + 1) : 0;
+}
+ 
+int main()
+{
+	int x[D_CONST] = {0, 1, 0}, y[D_CONST] = {0};
+	return pascals(x, y, 0);
+}

--- a/demo/cpp.cpp
+++ b/demo/cpp.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <iomanip>
+
+using namespace std;
+
+int **comb(int **a, int row, int col)
+{
+  int mid = col / 2;
+  //clear matrix
+  for (int i = 0; i < row; i++)
+    for (int j = 0; j < col; j++)
+      a[i][j] = 0;
+  a[0][mid] = 1; //put 1 in the middle of first row
+                 //build up Pascal's Triangle matrix
+  for (int i = 1; i < row; i++)
+  {
+    for (int j = 1; j < col - 1; j++)
+      a[i][j] = a[i - 1][j - 1] + a[i - 1][j + 1];
+  }
+  return a;
+}
+void disp(int **ptr, int row, int col)
+{
+  cout << endl
+       << endl;
+  for (int i = 0; i < row; i++)
+  {
+    for (int j = 0; j < col; j++)
+    {
+      if (ptr[i][j] == 0)
+        cout << "   ";
+      else
+        cout << setw(4) << right << ptr[i][j];
+    }
+    cout << endl;
+  }
+  cout << endl
+       << endl;
+}
+int main()
+{
+  int **ptr, m, n;
+  cout << "\nEnter number of rows to draw Pascal's Triangle: ";
+  cin >> m;
+  n = 2 * m + 1; //column = 2 * row + 1
+
+  ptr = new int *[m];
+  for (int i = 0; i < m; i++)
+    ptr[i] = new int[n];
+
+  ptr = comb(ptr, m, n); //calling function for array creation
+
+  disp(ptr, m, n); //calling function for array displaying.
+
+  return 0;
+}

--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -1659,8 +1659,14 @@
         "keyword.cpp",
         "keyword.control.c",
         "keyword.control.cpp",
+        "keyword.control.directive.conditional.c",
+        "keyword.control.directive.undef.c",
+        "keyword.control.directive.define.c",
+        "keyword.control.directive.pragma.c",
         "keyword.control.directive.include.c",
-        "keyword.control.directive.define.c"
+        "keyword.control.directive.line.c",
+        "keyword.control.directive.diagnostic.error.c",
+        "keyword.control.directive.diagnostic.warning.c"
       ],
       "settings": {
         "foreground": "#c792eaff"

--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -1670,8 +1670,7 @@
       "name": "C/C++ Functions",
       "scope": [
         "meta.function-call.c",
-        "entity.name.function.preprocessor.c",
-        "entity.name.function.c"
+        "entity.name.function.preprocessor.c"
       ],
       "settings": {
         "foreground": "#d6deebff"

--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -1651,6 +1651,41 @@
       "settings": {
         "fontStyle": ""
       }
+    },
+    {
+      "name": "C/C++ Keywords",
+      "scope": [
+        "keyword.c",
+        "keyword.cpp",
+        "keyword.control.c",
+        "keyword.control.cpp",
+        "keyword.control.directive.include.c",
+        "keyword.control.directive.define.c"
+      ],
+      "settings": {
+        "foreground": "#c792eaff"
+      }
+    },
+    {
+      "name": "C/C++ Functions",
+      "scope": [
+        "meta.function-call.c",
+        "entity.name.function.preprocessor.c",
+        "entity.name.function.c"
+      ],
+      "settings": {
+        "foreground": "#d6deebff"
+      }
+    },
+    {
+      "name": "C/C++ Include Strings",
+      "scope": [
+        "punctuation.definition.string.begin.c",
+        "punctuation.definition.string.end.c"
+      ],
+      "settings": {
+        "foreground": "#ecc48dff"
+      }
     }
   ]
 }

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -1662,6 +1662,41 @@
       "settings": {
         "fontStyle": ""
       }
+    },
+    {
+      "name": "C/C++ Keywords",
+      "scope": [
+        "keyword.c",
+        "keyword.cpp",
+        "keyword.control.c",
+        "keyword.control.cpp",
+        "keyword.control.directive.include.c",
+        "keyword.control.directive.define.c"
+      ],
+      "settings": {
+        "foreground": "#c792eaff"
+      }
+    },
+    {
+      "name": "C/C++ Functions",
+      "scope": [
+        "meta.function-call.c",
+        "entity.name.function.preprocessor.c",
+        "entity.name.function.c"
+      ],
+      "settings": {
+        "foreground": "#d6deebff"
+      }
+    },
+    {
+      "name": "C/C++ Include Strings",
+      "scope": [
+        "punctuation.definition.string.begin.c",
+        "punctuation.definition.string.end.c"
+      ],
+      "settings": {
+        "foreground": "#ecc48dff"
+      }
     }
   ]
 }

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -1681,8 +1681,7 @@
       "name": "C/C++ Functions",
       "scope": [
         "meta.function-call.c",
-        "entity.name.function.preprocessor.c",
-        "entity.name.function.c"
+        "entity.name.function.preprocessor.c"
       ],
       "settings": {
         "foreground": "#d6deebff"

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -1670,8 +1670,14 @@
         "keyword.cpp",
         "keyword.control.c",
         "keyword.control.cpp",
+        "keyword.control.directive.conditional.c",
+        "keyword.control.directive.undef.c",
+        "keyword.control.directive.define.c",
+        "keyword.control.directive.pragma.c",
         "keyword.control.directive.include.c",
-        "keyword.control.directive.define.c"
+        "keyword.control.directive.line.c",
+        "keyword.control.directive.diagnostic.error.c",
+        "keyword.control.directive.diagnostic.warning.c"
       ],
       "settings": {
         "foreground": "#c792eaff"


### PR DESCRIPTION
I have normalised the C/C++ colours a bit to offer better readability. Function parameters were previously all blue which led to some visual clutter. Keywords and include statements have also been changed to a single colour. This follows most other IDE themes that I've seen in the past.

I have added demo/c.c and demo cpp.cpp for examples of both C and C++ languages.

This is related to issue #138 