### PR TITLE
Update warn widget color

### DIFF
--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -25,7 +25,7 @@
     "inputValidation.errorBorder": "#EF5350",
     "inputValidation.infoBackground": "#64b5f6f2",
     "inputValidation.infoBorder": "#64B5F6",
-    "inputValidation.warningBackground": "#ffca28f2",
+    "inputValidation.warningBackground": "#8E6C03F2",
     "inputValidation.warningBorder": "#FFCA28",
     "scrollbar.shadow": "#010b14",
     "scrollbarSlider.activeBackground": "#084d8180",

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -25,7 +25,7 @@
     "inputValidation.errorBorder": "#EF5350",
     "inputValidation.infoBackground": "#64b5f6f2",
     "inputValidation.infoBorder": "#64B5F6",
-    "inputValidation.warningBackground": "#ffca28f2",
+    "inputValidation.warningBackground": "#8E6C03F2",
     "inputValidation.warningBorder": "#FFCA28",
     "scrollbar.shadow": "#010b14",
     "scrollbarSlider.activeBackground": "#084d8180",


### PR DESCRIPTION
Updated warn widget color as it was hard to see white text in such light background.

Closes #140

### Before
![](https://user-images.githubusercontent.com/10441177/45811791-bb86d880-bcd6-11e8-87ad-0ef231109c8c.png)

### After

![](https://user-images.githubusercontent.com/10441177/45813251-c5aad600-bcda-11e8-95f4-599cae3a8338.png)