### PR TITLE
Add symbol highlighting and add to demo

### DIFF
--- a/demo/ruby.rb
+++ b/demo/ruby.rb
@@ -29,6 +29,13 @@ module ExampleModule
     end
 
     private_class_method :private
+
+    private
+
+    def user_params
+      params.require(:user).permit(:username, :email, :password)
+      params.pluck(:user)
+    end
   end
 end
 

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -1262,6 +1262,13 @@
       }
     },
     {
+      "name": "Ruby Symbols",
+      "scope": "constant.language.symbol.ruby",
+      "settings": {
+        "foreground": "#7fdbca"
+      }
+    },
+    {
       "name": "LESS Tag names",
       "scope": "entity.name.tag.less",
       "settings": {


### PR DESCRIPTION
Tiny fix, I noticed that symbol syntax wasn't getting picked up for Ruby:

![screen shot 2018-10-23 at 5 04 24 pm](https://user-images.githubusercontent.com/22530815/47393708-e1443a80-d6e5-11e8-93e8-ba63dfb27f4a.png)

I added to the demo example and now it's differentiating symbols like this:
![screen shot 2018-10-23 at 5 04 31 pm](https://user-images.githubusercontent.com/22530815/47393760-0173f980-d6e6-11e8-9876-7b60450fcb49.png)

I'm by no means design-inclined, so if a different color would be more appropriate I'm definitely open to other options. 

The theme is great, by the way! Hope this helps.