### PR TITLE
No Italics Theme: Remove italics from git diff

### DIFF
--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -217,7 +217,6 @@
       ],
       "settings": {
         "foreground": "#a2bffc",
-        "fontStyle": "italic"
       }
     },
     {
@@ -225,7 +224,6 @@
       "scope": "markup.deleted.diff",
       "settings": {
         "foreground": "#EF535090",
-        "fontStyle": "italic"
       }
     },
     {
@@ -233,7 +231,6 @@
       "scope": "markup.inserted.diff",
       "settings": {
         "foreground": "#addb67ff",
-        "fontStyle": "italic"
       }
     },
     {


### PR DESCRIPTION
Italics were showing up in .diff files. This fixes that.

Addresses https://github.com/sdras/night-owl-vscode-theme/issues/153