### PR TITLE
fix python keywords color

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "python.linting.pylintEnabled": false
+  "python.linting.pylintEnabled": false,
 }

--- a/demo/python.py
+++ b/demo/python.py
@@ -1,9 +1,10 @@
 from collections import deque
 
+
 def topo(G, ind=None, Q=[1]):
+    if ind == None:
         ind = [0] * (len(G) + 1)  # this is a comment
-        ind = [0] * (len(G) + 1) #this is a comment
-        ind = [0] * (len(G) + 1)  # this is a comment
+        for u in G:
             for v in G[u]:
                 ind[v] += 1
         Q = deque()

--- a/demo/python.py
+++ b/demo/python.py
@@ -1,9 +1,9 @@
 from collections import deque
 
 def topo(G, ind=None, Q=[1]):
-    if ind == None:
+        ind = [0] * (len(G) + 1)  # this is a comment
         ind = [0] * (len(G) + 1) #this is a comment
-        for u in G:
+        ind = [0] * (len(G) + 1)  # this is a comment
             for v in G[u]:
                 ind[v] += 1
         Q = deque()

--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -206,8 +206,7 @@
     "string.quoted.single.js": "#ffffff",
     "meta.objectliteral.js": "#82AAFF"
   },
-  "tokenColors": [
-    {
+  "tokenColors": [{
       "name": "Changed",
       "scope": [
         "markup.changed",
@@ -378,7 +377,7 @@
       "name": "Function name",
       "scope": "entity.name.function",
       "settings": {
-        "foreground": "#82AAFF",
+        "foreground": "#DCDCAA",
         "fontStyle": ""
       }
     },
@@ -708,13 +707,12 @@
       "name": "Entity Name Function",
       "scope": ["entity.name.function"],
       "settings": {
-        "foreground": "#82AAFF",
+        "foreground": "#DCDCAA",
         "fontStyle": ""
       }
     },
     {
-      "name":
-        "Keyword Operator Comparison, returns, imports, and Keyword Operator Ruby",
+      "name": "Keyword Operator Comparison, returns, imports, and Keyword Operator Ruby",
       "scope": [
         "keyword.control.conditional.js",
         "keyword.operator.comparison",
@@ -742,8 +740,7 @@
       }
     },
     {
-      "name":
-        "Support Constant, `new` keyword, Special Method Keyword, `debugger`, other keywords",
+      "name": "Support Constant, `new` keyword, Special Method Keyword, `debugger`, other keywords",
       "scope": [
         "support.constant",
         "keyword.other.special-method",
@@ -1220,8 +1217,7 @@
     },
     {
       "name": "Specific JSON Property values like null",
-      "scope":
-        "meta.structure.dictionary.json meta.structure.dictionary.value constant.language",
+      "scope": "meta.structure.dictionary.json meta.structure.dictionary.value constant.language",
       "settings": {
         "foreground": "#ff5874"
       }
@@ -1263,8 +1259,7 @@
     },
     {
       "name": "Attribute Name for LESS",
-      "scope":
-        "meta.attribute-selector.less entity.other.attribute-name.attribute",
+      "scope": "meta.attribute-selector.less entity.other.attribute-name.attribute",
       "settings": {
         "foreground": "#F78C6C"
       }
@@ -1441,6 +1436,13 @@
       "scope": "source.python variable.language.special",
       "settings": {
         "foreground": "#8EACE3"
+      }
+    },
+    {
+      "name": "Python import control keyword",
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#c792ea"
       }
     },
     {

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -206,8 +206,7 @@
     "string.quoted.single.js": "#ffffff",
     "meta.objectliteral.js": "#82AAFF"
   },
-  "tokenColors": [
-    {
+  "tokenColors": [{
       "name": "Changed",
       "scope": [
         "markup.changed",
@@ -381,7 +380,7 @@
       "name": "Function name",
       "scope": "entity.name.function",
       "settings": {
-        "foreground": "#82AAFF",
+        "foreground": "#DCDCAA",
         "fontStyle": ""
       }
     },
@@ -711,13 +710,12 @@
       "name": "Entity Name Function",
       "scope": ["entity.name.function"],
       "settings": {
-        "foreground": "#82AAFF",
+        "foreground": "#DCDCAA",
         "fontStyle": ""
       }
     },
     {
-      "name":
-        "Keyword Operator Comparison, imports, returns and Keyword Operator Ruby",
+      "name": "Keyword Operator Comparison, imports, returns and Keyword Operator Ruby",
       "scope": [
         "keyword.operator.comparison",
         "keyword.control.flow.js",
@@ -755,8 +753,7 @@
       }
     },
     {
-      "name":
-        "Support Constant, `new` keyword, Special Method Keyword, `debugger`, other keywords",
+      "name": "Support Constant, `new` keyword, Special Method Keyword, `debugger`, other keywords",
       "scope": [
         "support.constant",
         "keyword.other.special-method",
@@ -1234,8 +1231,7 @@
     },
     {
       "name": "Specific JSON Property values like null",
-      "scope":
-        "meta.structure.dictionary.json meta.structure.dictionary.value constant.language",
+      "scope": "meta.structure.dictionary.json meta.structure.dictionary.value constant.language",
       "settings": {
         "foreground": "#ff5874"
       }
@@ -1284,8 +1280,7 @@
     },
     {
       "name": "Attribute Name for LESS",
-      "scope":
-        "meta.attribute-selector.less entity.other.attribute-name.attribute",
+      "scope": "meta.attribute-selector.less entity.other.attribute-name.attribute",
       "settings": {
         "foreground": "#F78C6C"
       }
@@ -1462,6 +1457,13 @@
       "scope": "source.python variable.language.special",
       "settings": {
         "foreground": "#8EACE3"
+      }
+    },
+    {
+      "name": "Python import control keyword",
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#c792ea"
       }
     },
     {

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -381,7 +381,7 @@
       "scope": "entity.name.function",
       "settings": {
         "foreground": "#DCDCAA",
-        "fontStyle": ""
+        "fontStyle": "italic"
       }
     },
     {
@@ -711,7 +711,7 @@
       "scope": ["entity.name.function"],
       "settings": {
         "foreground": "#DCDCAA",
-        "fontStyle": ""
+        "fontStyle": "italic"
       }
     },
     {


### PR DESCRIPTION
fixes #143 

Fixed 
 - bad coloring for `from`, `import`, `if`, `for`, `return` keywords
 - different color for function names
- italic support for function names

before:
![image](https://user-images.githubusercontent.com/8705386/49492663-347de100-f87f-11e8-9fcd-a4c543ae6cfe.png)

after:
![image](https://user-images.githubusercontent.com/8705386/49493320-b5d67300-f881-11e8-8001-bd902866840c.png)

