### PR TITLE
Tweak `README` to suggest a better marketplace search term

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ About this theme, and some of the considerations made while creating it (as well
 1.  Install [Visual Studio Code](https://code.visualstudio.com/)
 2.  Launch Visual Studio Code
 3.  Choose **Extensions** from menu
-4.  Search for `night-owl-vscode-theme`
+4.  Search for `night-owl`
 5.  Click **Install** to install it
 6.  Click **Reload** to reload the Code
 7.  From the menu bar click: Code > Preferences > Color Theme > **Night Owl**
@@ -36,7 +36,7 @@ The community is awesome and has ported this theme over to other environments
 - Atom: [https://atom.io/themes/night-owl-vs-code-syntax](https://atom.io/themes/night-owl-vs-code-syntax)
 - Jetbrains: [https://github.com/xdrop/night-owl-jetbrains](https://github.com/xdrop/night-owl-jetbrains)
 - Emacs: [https://github.com/aaronjensen/night-owl-emacs](https://github.com/aaronjensen/night-owl-emacs)
-- Vim 
+- Vim
   1. [https://github.com/Khaledgarbaya/night-owl-vim-theme](https://github.com/Khaledgarbaya/night-owl-vim-theme)
   2. [https://github.com/haishanh/night-owl.vim](https://github.com/haishanh/night-owl.vim)
 - Pygments [https://github.com/liamdawson/nightowl-pygments-style](https://github.com/liamdawson/nightowl-pygments-style)


### PR DESCRIPTION
Possible fix/workaround for https://github.com/Microsoft/vscode/issues/69810.

I noticed `night-owl-vscode-theme` isn't a thing that appears in the name, or keywords, only appearing as [part of the url](https://github.com/sdras/night-owl-vscode-theme/blob/f383bdbeabb54b04584d009af1e8acab2c868a95/package.json#L10).

We could try to search for something else, like `night-owl`, which is the name [specified for the package](https://github.com/sdras/night-owl-vscode-theme/blob/f383bdbeabb54b04584d009af1e8acab2c868a95/package.json#L2)?

![image](https://user-images.githubusercontent.com/426180/53767247-0d3cad00-3e8a-11e9-99e0-0dfcc49fbb17.png)