### PR TITLE
Updating right package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ About this theme, and some of the considerations made while creating it (as well
 1.  Install [Visual Studio Code](https://code.visualstudio.com/)
 2.  Launch Visual Studio Code
 3.  Choose **Extensions** from menu
-4.  Search for `night-owl`
+4.  Search for `night owl`
 5.  Click **Install** to install it
 6.  Click **Reload** to reload the Code
 7.  From the menu bar click: Code > Preferences > Color Theme > **Night Owl**


### PR DESCRIPTION
Searching `night-owl` on VS code does not show this package. The right search term is `night owl`. So, Updating the README with proper package name.

**Before**

![image](https://user-images.githubusercontent.com/10805204/60332401-5de59200-99b4-11e9-9515-40ac96923b40.png)

**After**

![image](https://user-images.githubusercontent.com/10805204/60332531-aa30d200-99b4-11e9-9e3f-8af0bbe38a19.png)

