### PR TITLE
Issue 223 - Fix text distortion on certain command pallets

### DIFF
--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -2,7 +2,6 @@
   "name": "Night Owl No Italics",
   "type": "dark",
   "colors": {
-    "contrastActiveBorder": "#122d42",
     "contrastBorder": "#122d42",
     "focusBorder": "#122d42",
     "foreground": "#d6deeb",

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -2,7 +2,6 @@
   "name": "Night Owl",
   "type": "dark",
   "colors": {
-    "contrastActiveBorder": "#122d42",
     "contrastBorder": "#122d42",
     "focusBorder": "#122d42",
     "foreground": "#d6deeb",


### PR DESCRIPTION
Fixes #223 

Currently `constrastActiveBorder` causes distortion on some command pallets that have descriptions such as the python `configure tests` pallet.

This looks like it might be an issue w/ adding `contrastActiveBorder` styling to any vscode theme.