### PR TITLE
Update code background color in hover contents

### DIFF
--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -197,6 +197,7 @@
     "terminal.ansiBrightYellow": "#ffeb95",
     "terminal.selectionBackground": "#1b90dd4d",
     "terminalCursor.background": "#234d70",
+    "textCodeBlock.background": "#4f4f4f",
     "debugToolBar.background": "#011627",
     "welcomePage.buttonBackground": "#011627",
     "welcomePage.buttonHoverBackground": "#011627",


### PR DESCRIPTION
I use a lot of JSDocs in my TypeScript code and sometimes include backticks to refer to code parts. The background color for this was very dark and not distinguishable. I made it into a lighter grey so it is much more readable.

Below is a screenshot of my update
<img width="620" alt="Screen Shot 2020-01-22 at 4 16 46 PM" src="https://user-images.githubusercontent.com/16144158/72935285-0bded200-3d33-11ea-903d-d9a46fc84da1.png">
