### PR TITLE
Fixed typescript highlighting issue #237

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the "night-owl" extension are be documented in this file.
 
+## "1.1.4"
+- fix typescript variable keyword highlighting inside classes
+
 ## "1.1.3"
 
 ### Light 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "night-owl",
   "displayName": "Night Owl",
   "description": "A VS Code theme for the night owls out there. Now introducing Light Owl theme for daytime usage. Decisions were based on meaningful contrast for reading comprehension and for optimal razzle dazzle. ✨",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "publisher": "sdras",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/themes/Night Owl-Light-color-theme-noitalic.json
+++ b/themes/Night Owl-Light-color-theme-noitalic.json
@@ -764,7 +764,7 @@
       "name": "Invalid Illegal",
       "scope": "invalid.illegal",
       "settings": {
-        "foreground": "#c96765",
+        "foreground": "#c96765"
       }
     },
     {
@@ -1676,6 +1676,16 @@
       "scope": ["entity.name.type.tsx", "entity.name.type.module.tsx"],
       "settings": {
         "foreground": "#111111"
+      }
+    },
+    {
+      "name": "TypeScript Class Variable Keyword",
+      "scope": [
+        "meta.class.ts meta.var.expr.ts storage.type.ts",
+        "meta.class.tsx meta.var.expr.tsx storage.type.tsx"
+      ],
+      "settings": {
+        "foreground": "#C792EA"
       }
     },
     {

--- a/themes/Night Owl-Light-color-theme.json
+++ b/themes/Night Owl-Light-color-theme.json
@@ -1713,6 +1713,16 @@
       }
     },
     {
+      "name": "TypeScript Class Variable Keyword",
+      "scope": [
+        "meta.class.ts meta.var.expr.ts storage.type.ts",
+        "meta.class.tsx meta.var.expr.tsx storage.type.tsx"
+      ],
+      "settings": {
+        "foreground": "#994CC3"
+      }
+    },
+    {
       "name": "TypeScript Method Declaration e.g. `constructor`",
       "scope": [
         "meta.method.declaration storage.type.ts",

--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -1718,6 +1718,16 @@
       }
     },
     {
+      "name": "TypeScript Class Variable Keyword",
+      "scope": [
+        "meta.class.ts meta.var.expr.ts storage.type.ts",
+        "meta.class.tsx meta.var.expr.tsx storage.type.tsx"
+      ],
+      "settings": {
+        "foreground": "#C792EA"
+      }
+    },
+    {
       "name": "TypeScript Method Declaration e.g. `constructor`",
       "scope": [
         "meta.method.declaration storage.type.ts",

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -1741,6 +1741,16 @@
       }
     },
     {
+      "name": "TypeScript Class Variable Keyword",
+      "scope": [
+        "meta.class.ts meta.var.expr.ts storage.type.ts",
+        "meta.class.tsx meta.var.expr.tsx storage.type.tsx"
+      ],
+      "settings": {
+        "foreground": "#C792EA"
+      }
+    },
+    {
       "name": "TypeScript Method Declaration e.g. `constructor`",
       "scope": [
         "meta.method.declaration storage.type.ts",


### PR DESCRIPTION
This is a patch that fixes the typescript variable class keyword highlighting issue referenced in #237. Open to feedback on the selector choice as this is my first time editing a VSCode theme!

![Screen Shot 2020-06-08 at 12 11 54 PM](https://user-images.githubusercontent.com/1349422/84054718-c9383200-a981-11ea-99ce-b6b513b5ec69.png)


If anyone is looking for a fix for this before this pull request is merged, you can find the VSIX extension file [here](https://github.com/sfred/night-owl-vscode-theme/releases/tag/1.1.4).