### PR TITLE
Fix invalid token colors

### DIFF
--- a/themes/Night Owl-Light-color-theme-noitalic.json
+++ b/themes/Night Owl-Light-color-theme-noitalic.json
@@ -426,16 +426,14 @@
       "name": "Invalid",
       "scope": "invalid",
       "settings": {
-        "background": "#ff2c83",
-        "foreground": "#ffffff"
+        "foreground": "#ff2c83"
       }
     },
     {
       "name": "Invalid deprecated",
       "scope": "invalid.deprecated",
       "settings": {
-        "foreground": "#ffffff",
-        "background": "#d3423e"
+        "foreground": "#d3423e"
       }
     },
     {
@@ -748,23 +746,21 @@
       "name": "Invalid Broken",
       "scope": "invalid.broken",
       "settings": {
-        "foreground": "#020e14",
-        "background": "#aa0982"
+        "foreground": "#aa0982"
       }
     },
     {
       "name": "Invalid Unimplemented",
       "scope": "invalid.unimplemented",
       "settings": {
-        "background": "#8BD649",
-        "foreground": "#ffffff"
+        "foreground": "#8BD649"
       }
     },
     {
       "name": "Invalid Illegal",
       "scope": "invalid.illegal",
       "settings": {
-        "foreground": "#c96765",
+        "foreground": "#c96765"
       }
     },
     {

--- a/themes/Night Owl-Light-color-theme.json
+++ b/themes/Night Owl-Light-color-theme.json
@@ -434,16 +434,14 @@
       "name": "Invalid",
       "scope": "invalid",
       "settings": {
-        "background": "#ff2c83",
-        "foreground": "#ffffff"
+        "foreground": "#ff2c83"
       }
     },
     {
       "name": "Invalid deprecated",
       "scope": "invalid.deprecated",
       "settings": {
-        "foreground": "#ffffff",
-        "background": "#d3423e"
+        "foreground": "#d3423e"
       }
     },
     {
@@ -763,23 +761,21 @@
       "name": "Invalid Broken",
       "scope": "invalid.broken",
       "settings": {
-        "foreground": "#020e14",
-        "background": "#aa0982"
+        "foreground": "#aa0982"
       }
     },
     {
       "name": "Invalid Unimplemented",
       "scope": "invalid.unimplemented",
       "settings": {
-        "background": "#8BD649",
-        "foreground": "#ffffff"
+        "foreground": "#8BD649"
       }
     },
     {
       "name": "Invalid Illegal",
       "scope": "invalid.illegal",
       "settings": {
-        "foreground": "#c96765",
+        "foreground": "#c96765"
       }
     },
     {


### PR DESCRIPTION
@sdras made a similar change in #193, specifically commit https://github.com/sdras/night-owl-vscode-theme/commit/96279d23bfb3094ac1d6b16fc586c90fb678a515
This addresses #218 and updates the rest of the invalid token colors. (This is a refresh of #219)

In simple terms, many invalid tokens use a background color with white text — but since background colors aren't supported, the result is just white text:

<img width="577" alt="Sample code with incorrect highlighting" src="https://user-images.githubusercontent.com/2044842/60686722-5b28e800-9e5f-11e9-91a5-a8fd465fc250.png">

So in this PR I swap the background color to the foreground, and remove the background declaration.

<img width="577" alt="Sample code with correct highlighting" src="https://user-images.githubusercontent.com/2044842/60916104-70788a80-a242-11e9-8a46-de6f5cd357d3.png">

Thanks for the reminder @macguirerintoul