### PR TITLE
Add Night Owl and Light Owl themes for Alacritty

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ The community is awesome and has ported this theme over to other environments.
 - Visual Studio 2019: [https://github.com/kai-oswald/NightOwl-VS-Theme](https://github.com/kai-oswald/NightOwl-VS-Theme)
 - Prism [https://github.com/SaraVieira/prism-theme-night-owl](https://github.com/SaraVieira/prism-theme-night-owl)
 - Windows Terminal [https://github.com/edurojasr/Windows_Terminal_Theme_Night_Owl](https://github.com/edurojasr/Windows_Terminal_Theme_Night_Owl)
-- Alacritty: [https://github.com/nik27/night-owl-alacritty-theme](https://github.com/nik27/night-owl-alacritty-theme)
 
 #### Light Theme
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ The community is awesome and has ported this theme over to other environments.
 - Visual Studio 2019: [https://github.com/kai-oswald/NightOwl-VS-Theme](https://github.com/kai-oswald/NightOwl-VS-Theme)
 - Prism [https://github.com/SaraVieira/prism-theme-night-owl](https://github.com/SaraVieira/prism-theme-night-owl)
 - Windows Terminal [https://github.com/edurojasr/Windows_Terminal_Theme_Night_Owl](https://github.com/edurojasr/Windows_Terminal_Theme_Night_Owl)
+- Alacritty: [https://github.com/nik27/night-owl-alacritty-theme](https://github.com/nik27/night-owl-alacritty-theme)
 
 #### Light Theme
 
 - iTerm2: [https://github.com/fcaldera/night-owl-light-iterm2](https://github.com/fcaldera/night-owl-light-iterm2)
 - Vim: [https://github.com/macguirerintoul/night_owl_light.vim](https://github.com/macguirerintoul/night_owl_light.vim)
+- Alacritty: [https://github.com/nik27/night-owl-alacritty-theme](https://github.com/nik27/night-owl-alacritty-theme)
 
 ## Separate the Editor from the Sidebar
 


### PR DESCRIPTION
Add Night Owl and Light Owl themes for Alacritty terminal.
![showcase](https://user-images.githubusercontent.com/43588994/99831892-0f640500-2b60-11eb-970c-baa5d2abf803.png)
