### PR TITLE
feat: inlay hint colors for dark themes

### DIFF
--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -111,6 +111,8 @@
     "editorGutter.background": "#011627",
     "editorGutter.modifiedBackground": "#e2b93d",
     "editorGutter.addedBackground": "#9CCC65",
+    "editorInlayHint.background": "#0000",
+    "editorInlayHint.foreground": "#829D9D",
     "editorGutter.deletedBackground": "#EF5350",
     "diffEditor.insertedTextBackground": "#99b76d23",
     "diffEditor.insertedTextBorder": "#c5e47833",

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -112,6 +112,8 @@
     "editorGutter.modifiedBackground": "#e2b93d",
     "editorGutter.addedBackground": "#9CCC65",
     "editorGutter.deletedBackground": "#EF5350",
+    "editorInlayHint.background": "#0000",
+    "editorInlayHint.foreground": "#829D9D",
     "diffEditor.insertedTextBackground": "#99b76d23",
     "diffEditor.insertedTextBorder": "#c5e47833",
     "diffEditor.removedTextBackground": "#ef535033",


### PR DESCRIPTION
Better colors for built-in editor inlay hints. They stand out waaaaay too much by default.

Original:
![image](https://user-images.githubusercontent.com/40751395/131074551-5e04b7d0-4ddc-42e9-8c2f-2591eb9910a6.png)

This PR:
![image](https://user-images.githubusercontent.com/40751395/131074576-bd85be62-8420-4d7b-9530-f7661a9a9373.png)
