### PR TITLE
Fix invalid scope typo "definintion"

### DIFF
--- a/themes/Night Owl-Light-color-theme-noitalic.json
+++ b/themes/Night Owl-Light-color-theme-noitalic.json
@@ -1690,7 +1690,7 @@
         "keyword.operator.type",
         "keyword.operator",
         "keyword",
-        "punctuation.definintion.string",
+        "punctuation.definition.string",
         "punctuation",
         "variable.other.readwrite.js",
         "storage.type",

--- a/themes/Night Owl-Light-color-theme.json
+++ b/themes/Night Owl-Light-color-theme.json
@@ -1734,7 +1734,7 @@
         "keyword.operator.type",
         "keyword.operator",
         "keyword",
-        "punctuation.definintion.string",
+        "punctuation.definition.string",
         "punctuation",
         "variable.other.readwrite.js",
         "storage.type",

--- a/themes/Night Owl-color-theme-noitalic.json
+++ b/themes/Night Owl-color-theme-noitalic.json
@@ -1794,7 +1794,7 @@
         "keyword.operator.type",
         "keyword.operator",
         "keyword",
-        "punctuation.definintion.string",
+        "punctuation.definition.string",
         "punctuation",
         "variable.other.readwrite.js",
         "storage.type",

--- a/themes/Night Owl-color-theme.json
+++ b/themes/Night Owl-color-theme.json
@@ -1817,7 +1817,7 @@
         "keyword.operator.type",
         "keyword.operator",
         "keyword",
-        "punctuation.definintion.string",
+        "punctuation.definition.string",
         "punctuation",
         "variable.other.readwrite.js",
         "storage.type",


### PR DESCRIPTION
Typo fix for `punctuation.definition.string` (was `definintion`)