### PR TITLE
light: use notification colors for editor inlay hints

### DIFF
--- a/themes/Night Owl-Light-color-theme-noitalic.json
+++ b/themes/Night Owl-Light-color-theme-noitalic.json
@@ -103,6 +103,8 @@
     "editorRuler.foreground": "#d9d9d9",
     "editorOverviewRuler.errorForeground": "#E64D49",
     "editorOverviewRuler.warningForeground": "#daaa01",
+    "editorInlayHint.background": "#F0F0F0",
+    "editorInlayHint.foreground": "#403f53",
     "editorWidget.background": "#F0F0F0",
     "editorWidget.border": "#d9d9d9",
     "editorSuggestWidget.background": "#F0F0F0",

--- a/themes/Night Owl-Light-color-theme.json
+++ b/themes/Night Owl-Light-color-theme.json
@@ -116,6 +116,8 @@
     "editorRuler.foreground": "#d9d9d9",
     "editorOverviewRuler.errorForeground": "#E64D49",
     "editorOverviewRuler.warningForeground": "#daaa01",
+    "editorInlayHint.background": "#F0F0F0",
+    "editorInlayHint.foreground": "#403f53",
     // Editor Widget
     "editorWidget.background": "#F0F0F0",
     "editorWidget.border": "#d9d9d9",


### PR DESCRIPTION
editor inlay hints are barely visible in the light theme
this change applies the notification colors to inlay hints to change that