### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The community is awesome and has ported this theme over to other environments.
 
 ## Separate the Editor from the Sidebar
 
-This theme uses contrast sparingly so that when it's applied, it's more meaningful. This can help reduce noise and improve your ability to scan. However, some of the decisions may not work for everyone. One such decision that some disagree on is whether or not to have a separation between the editor and sidebar, and the amount of contrast. If you wish for this to have more visual signifigance, please paste this into your user settings preferences. These are my recommendations for these settings but you can use whatever colors you wish. ☺️
+This theme uses contrast sparingly so that when it's applied, it's more meaningful. This can help reduce noise and improve your ability to scan. However, some of the decisions may not work for everyone. One such decision that some disagree on is whether or not to have a separation between the editor and sidebar, and the amount of contrast. If you wish for this to have more visual significance, please paste this into your user settings preferences. These are my recommendations for these settings but you can use whatever colors you wish. ☺️
 
 ```
 "workbench.colorCustomizations": {


### PR DESCRIPTION
Fix a typo in the README, `Separate the Editor from the Sidebar` section.