### PR TITLE
Changed the warning line in the light theme to a single line for consistency with the dark theme

### DIFF
--- a/themes/Night Owl-Light-color-theme-noitalic.json
+++ b/themes/Night Owl-Light-color-theme-noitalic.json
@@ -96,7 +96,7 @@
     "editorError.foreground": "#E64D49",
     "editorError.border": "#FBFBFB",
     "editorWarning.foreground": "#daaa01",
-    "editorWarning.border": "#daaa01",
+    "editorWarning.border": null,
     "editorGutter.addedBackground": "#49d0c5",
     "editorGutter.modifiedBackground": "#6fbef6",
     "editorGutter.deletedBackground": "#f76e6e",

--- a/themes/Night Owl-Light-color-theme.json
+++ b/themes/Night Owl-Light-color-theme.json
@@ -109,7 +109,7 @@
     "editorError.foreground": "#E64D49",
     "editorError.border": "#FBFBFB",
     "editorWarning.foreground": "#daaa01",
-    "editorWarning.border": "#daaa01",
+    "editorWarning.border": null,
     "editorGutter.addedBackground": "#49d0c5",
     "editorGutter.modifiedBackground": "#6fbef6",
     "editorGutter.deletedBackground": "#f76e6e",


### PR DESCRIPTION
![result](https://github.com/sdras/night-owl-vscode-theme/assets/45549589/ee732a73-f372-49e1-aadb-6f6e1bee59a0)
issue #322